### PR TITLE
Detecting custom ArgParser instances and ArgParse outside of main

### DIFF
--- a/wooey/backend/argparse_to_json.py
+++ b/wooey/backend/argparse_to_json.py
@@ -214,7 +214,10 @@ def as_json(action, widget):
         defaultval = action.default
     else:
         # This will work for classes or functions; might need to catch more here
-        defaultval = action.default.__name__
+        if issubclass(type(action.default), file):
+            defaultval = action.default.name
+        else:
+            defaultval = action.default.__name__
 
     return {
         'name': action.dest,


### PR DESCRIPTION
The source parser is a bit limited for finding argparse instances without standard names, as well as subclasses ArgParser instances. I was working on a related project for making a django server from any argparse script, and found using the imp module is superior. Here's a sample using it that should be a drop-in replacement that falls back to your approach for one case where the required flag causes an error with loading the source via the imp module.